### PR TITLE
Optimize team list data loading

### DIFF
--- a/src/components/teams-filter-bar.tsx
+++ b/src/components/teams-filter-bar.tsx
@@ -11,11 +11,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { TeamWithRelations } from '@/types/team'
+import { TeamWithCounts } from '@/types/team'
 
 interface TeamsFilterBarProps {
-  teams: TeamWithRelations[]
-  onFilteredTeamsChange: (_filteredTeams: TeamWithRelations[]) => void
+  teams: TeamWithCounts[]
+  onFilteredTeamsChange: (_filteredTeams: TeamWithCounts[]) => void
 }
 
 export function TeamsFilterBar({
@@ -100,31 +100,27 @@ export function TeamsFilterBar({
     // Members filter
     if (membersFilter !== 'all') {
       if (membersFilter === 'has-members') {
-        filtered = filtered.filter(team => team.people.length > 0)
+        filtered = filtered.filter(team => team._count.people > 0)
       } else if (membersFilter === 'no-members') {
-        filtered = filtered.filter(team => team.people.length === 0)
+        filtered = filtered.filter(team => team._count.people === 0)
       }
     }
 
     // Initiatives filter
     if (initiativesFilter !== 'all') {
       if (initiativesFilter === 'has-initiatives') {
-        filtered = filtered.filter(team => team.initiatives.length > 0)
+        filtered = filtered.filter(team => team._count.initiatives > 0)
       } else if (initiativesFilter === 'no-initiatives') {
-        filtered = filtered.filter(team => team.initiatives.length === 0)
+        filtered = filtered.filter(team => team._count.initiatives === 0)
       }
     }
 
     // Children filter
     if (childrenFilter !== 'all') {
       if (childrenFilter === 'has-children') {
-        filtered = filtered.filter(
-          team => team.children && team.children.length > 0
-        )
+        filtered = filtered.filter(team => team._count.children > 0)
       } else if (childrenFilter === 'no-children') {
-        filtered = filtered.filter(
-          team => !team.children || team.children.length === 0
-        )
+        filtered = filtered.filter(team => team._count.children === 0)
       }
     }
 

--- a/src/components/teams-page-client.tsx
+++ b/src/components/teams-page-client.tsx
@@ -3,14 +3,14 @@
 import { useState, useEffect, useCallback } from 'react'
 import { TeamsTable } from '@/components/teams-table'
 import { TeamsFilterBar } from '@/components/teams-filter-bar'
-import { TeamWithRelations } from '@/types/team'
+import { TeamWithCounts } from '@/types/team'
 
 interface TeamsPageClientProps {
-  teams: TeamWithRelations[]
+  teams: TeamWithCounts[]
 }
 
 export function TeamsPageClient({ teams }: TeamsPageClientProps) {
-  const [filteredTeams, setFilteredTeams] = useState<TeamWithRelations[]>(teams)
+  const [filteredTeams, setFilteredTeams] = useState<TeamWithCounts[]>(teams)
 
   // Update filtered teams when teams prop changes
   useEffect(() => {
@@ -18,7 +18,7 @@ export function TeamsPageClient({ teams }: TeamsPageClientProps) {
   }, [teams])
 
   const handleFilteredTeamsChange = useCallback(
-    (newFilteredTeams: TeamWithRelations[]) => {
+    (newFilteredTeams: TeamWithCounts[]) => {
       setFilteredTeams(newFilteredTeams)
     },
     []

--- a/src/components/teams-table.tsx
+++ b/src/components/teams-table.tsx
@@ -32,7 +32,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { deleteTeam } from '@/lib/actions'
 import { toast } from 'sonner'
-import { TeamWithRelations } from '@/types/team'
+import { TeamWithCounts } from '@/types/team'
 
 interface SortState {
   column: string | null
@@ -40,7 +40,7 @@ interface SortState {
 }
 
 interface TeamsTableProps {
-  teams: TeamWithRelations[]
+  teams: TeamWithCounts[]
   onTeamUpdate?: () => void
 }
 
@@ -102,16 +102,16 @@ export function TeamsTable({ teams, onTeamUpdate }: TeamsTableProps) {
             bValue = b.parent?.name?.toLowerCase() || ''
             break
           case 'members':
-            aValue = a.people.length
-            bValue = b.people.length
+            aValue = a._count.people
+            bValue = b._count.people
             break
           case 'initiatives':
-            aValue = a.initiatives.length
-            bValue = b.initiatives.length
+            aValue = a._count.initiatives
+            bValue = b._count.initiatives
             break
           case 'children':
-            aValue = a.children?.length || 0
-            bValue = b.children?.length || 0
+            aValue = a._count.children
+            bValue = b._count.children
             break
           default:
             return 0
@@ -243,19 +243,19 @@ export function TeamsTable({ teams, onTeamUpdate }: TeamsTableProps) {
                 <TableCell className='text-center text-muted-foreground'>
                   <div className='flex items-center justify-center gap-1'>
                     <Users className='h-3 w-3' />
-                    {team.people.length}
+                    {team._count.people}
                   </div>
                 </TableCell>
                 <TableCell className='text-center text-muted-foreground'>
                   <div className='flex items-center justify-center gap-1'>
                     <Target className='h-3 w-3' />
-                    {team.initiatives.length}
+                    {team._count.initiatives}
                   </div>
                 </TableCell>
                 <TableCell className='text-center text-muted-foreground'>
                   <div className='flex items-center justify-center gap-1'>
                     <Building2 className='h-3 w-3' />
-                    {team.children?.length || 0}
+                    {team._count.children}
                   </div>
                 </TableCell>
                 <TableCell onClick={e => e.stopPropagation()}>

--- a/src/lib/actions/team.ts
+++ b/src/lib/actions/team.ts
@@ -9,6 +9,7 @@ import type {
   TeamWithHierarchy,
   TeamForSelection,
   TeamWithRelations,
+  TeamWithCounts,
 } from '@/types/team'
 
 export async function getTeams() {
@@ -28,10 +29,10 @@ export async function getTeams() {
 }
 
 /**
- * Gets all teams with their relations for data table display
+ * Gets all teams with parent info and relation counts for data table display
  * Returns a flat list of all teams (not hierarchical)
  */
-export async function getAllTeamsWithRelations(): Promise<TeamWithRelations[]> {
+export async function getAllTeamsWithRelations(): Promise<TeamWithCounts[]> {
   try {
     const user = await getCurrentUser()
     if (!user.organizationId) {
@@ -40,10 +41,19 @@ export async function getAllTeamsWithRelations(): Promise<TeamWithRelations[]> {
     return await prisma.team.findMany({
       where: { organizationId: user.organizationId },
       include: {
-        people: true,
-        initiatives: true,
-        parent: true,
-        children: true,
+        parent: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+        _count: {
+          select: {
+            people: true,
+            initiatives: true,
+            children: true,
+          },
+        },
       },
       orderBy: { name: 'asc' },
     })

--- a/src/types/team.ts
+++ b/src/types/team.ts
@@ -26,3 +26,12 @@ export type TeamWithRelations = Team & {
   parent: Team | null
   children: Team[]
 }
+
+export type TeamWithCounts = Team & {
+  parent: Pick<Team, 'id' | 'name'> | null
+  _count: {
+    people: number
+    initiatives: number
+    children: number
+  }
+}


### PR DESCRIPTION
## Summary
- shrink the team listing query to only return parent info and relation counts
- update team list types and UI components to consume the lighter-weight payload

## Testing
- npm run lint *(fails: missing @eslint/eslintrc dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de6c798ab88326887d0c5eaf0ae9af