### PR TITLE
Reduce redundant data fetching in person detail view

### DIFF
--- a/src/app/people/[id]/page.tsx
+++ b/src/app/people/[id]/page.tsx
@@ -130,6 +130,8 @@ export default async function PersonDetailPage({
         linkedAvatars={linkedAvatars}
         isAdmin={isAdmin(session.user)}
         currentPerson={currentPersonWithLevel}
+        organizationId={session.user.organizationId}
+        currentUserId={session.user.id}
       />
     </PersonDetailClient>
   )

--- a/src/components/people/person-detail-content.tsx
+++ b/src/components/people/person-detail-content.tsx
@@ -56,6 +56,8 @@ interface PersonDetailContentProps {
   } | null
   isAdmin: boolean
   currentPerson?: PersonWithDetailRelations
+  organizationId: string
+  currentUserId: string
 }
 
 export function PersonDetailContent({
@@ -63,6 +65,8 @@ export function PersonDetailContent({
   linkedAvatars,
   isAdmin,
   currentPerson,
+  organizationId,
+  currentUserId,
 }: PersonDetailContentProps) {
   return (
     <div className='page-container'>
@@ -168,28 +172,42 @@ export function PersonDetailContent({
               <FeedbackSection
                 personId={person.id}
                 person={person as unknown as PrismaPerson}
+                currentPersonId={currentPerson?.id}
               />
             </Suspense>
 
             {/* Feedback Campaigns Section */}
             <Suspense fallback={<FeedbackCampaignsSectionSkeleton />}>
-              <FeedbackCampaignsSection personId={person.id} />
+              <FeedbackCampaignsSection
+                personId={person.id}
+                organizationId={organizationId}
+                currentUserId={currentUserId}
+              />
             </Suspense>
           </div>
 
           {/* Owned Initiatives */}
           <Suspense fallback={<OwnedInitiativesSectionSkeleton />}>
-            <OwnedInitiativesSection personId={person.id} />
+            <OwnedInitiativesSection
+              personId={person.id}
+              organizationId={organizationId}
+            />
           </Suspense>
 
           {/* Active Tasks */}
           <Suspense fallback={<ActiveTasksSectionSkeleton />}>
-            <ActiveTasksSection personId={person.id} />
+            <ActiveTasksSection
+              personId={person.id}
+              organizationId={organizationId}
+            />
           </Suspense>
 
           {/* 1:1 Meetings */}
           <Suspense fallback={<OneOnOneMeetingsSectionSkeleton />}>
-            <OneOnOneMeetingsSection personId={person.id} />
+            <OneOnOneMeetingsSection
+              personId={person.id}
+              organizationId={organizationId}
+            />
           </Suspense>
 
           {/* Jira Work Activity - Show if person has Jira account */}
@@ -215,12 +233,18 @@ export function PersonDetailContent({
         <div className='w-full lg:w-80 space-y-6'>
           {/* Synopsis Section */}
           <Suspense fallback={<SynopsisSectionSkeleton />}>
-            <SynopsisSection personId={person.id} />
+            <SynopsisSection
+              personId={person.id}
+              organizationId={organizationId}
+            />
           </Suspense>
 
           {/* Direct Reports */}
           <Suspense fallback={<DirectReportsSectionSkeleton />}>
-            <DirectReportsSection personId={person.id} />
+            <DirectReportsSection
+              personId={person.id}
+              organizationId={organizationId}
+            />
           </Suspense>
 
           {/* User Account Link - Only show for admins */}

--- a/src/components/people/sections/active-tasks-section.tsx
+++ b/src/components/people/sections/active-tasks-section.tsx
@@ -1,22 +1,20 @@
 import { prisma } from '@/lib/db'
-import { getServerSession } from 'next-auth'
-import { authOptions } from '@/lib/auth'
 import { TaskTable } from '@/components/tasks/task-table'
 import { SectionHeader } from '@/components/ui/section-header'
 import { ListTodo } from 'lucide-react'
-import { getPeople } from '@/lib/actions/person'
+import { getActivePeopleForOrganization } from '@/lib/data/people'
 import { TASK_LIST_SELECT } from '@/lib/task-list-select'
 
 interface ActiveTasksSectionProps {
   personId: string
+  organizationId: string
 }
 
 export async function ActiveTasksSection({
   personId,
+  organizationId,
 }: ActiveTasksSectionProps) {
-  const session = await getServerSession(authOptions)
-
-  if (!session?.user?.organizationId) {
+  if (!organizationId) {
     return null
   }
 
@@ -38,7 +36,7 @@ export async function ActiveTasksSection({
   }
 
   // Get people data for TaskTable
-  const people = await getPeople()
+  const people = await getActivePeopleForOrganization(organizationId)
 
   return (
     <section>

--- a/src/components/people/sections/direct-reports-section.tsx
+++ b/src/components/people/sections/direct-reports-section.tsx
@@ -1,20 +1,18 @@
 import { prisma } from '@/lib/db'
-import { getServerSession } from 'next-auth'
-import { authOptions } from '@/lib/auth'
 import { SectionHeader } from '@/components/ui/section-header'
 import { PersonListItem } from '@/components/people/person-list-item'
 import { Users } from 'lucide-react'
 
 interface DirectReportsSectionProps {
   personId: string
+  organizationId: string
 }
 
 export async function DirectReportsSection({
   personId,
+  organizationId,
 }: DirectReportsSectionProps) {
-  const session = await getServerSession(authOptions)
-
-  if (!session?.user?.organizationId) {
+  if (!organizationId) {
     return null
   }
 
@@ -22,7 +20,7 @@ export async function DirectReportsSection({
   const reports = await prisma.person.findMany({
     where: {
       managerId: personId,
-      organizationId: session.user.organizationId,
+      organizationId,
       status: 'active',
     },
     include: {

--- a/src/components/people/sections/feedback-campaigns-section.tsx
+++ b/src/components/people/sections/feedback-campaigns-section.tsx
@@ -1,6 +1,4 @@
 import { prisma } from '@/lib/db'
-import { getServerSession } from 'next-auth'
-import { authOptions } from '@/lib/auth'
 import { PersonFeedbackCampaigns } from '@/components/people/person-feedback-campaigns'
 import { SectionHeader } from '@/components/ui/section-header'
 import { Button } from '@/components/ui/button'
@@ -9,14 +7,16 @@ import Link from 'next/link'
 
 interface FeedbackCampaignsSectionProps {
   personId: string
+  organizationId: string
+  currentUserId: string
 }
 
 export async function FeedbackCampaignsSection({
   personId,
+  organizationId,
+  currentUserId,
 }: FeedbackCampaignsSectionProps) {
-  const session = await getServerSession(authOptions)
-
-  if (!session?.user?.organizationId) {
+  if (!organizationId) {
     return null
   }
 
@@ -26,10 +26,10 @@ export async function FeedbackCampaignsSection({
       status: {
         in: ['active', 'draft'],
       },
-      userId: session.user.id,
+      userId: currentUserId,
       targetPersonId: personId,
       targetPerson: {
-        organizationId: session.user.organizationId,
+        organizationId,
       },
     },
     include: {

--- a/src/components/people/sections/github-linking-section.tsx
+++ b/src/components/people/sections/github-linking-section.tsx
@@ -1,5 +1,3 @@
-import { getServerSession } from 'next-auth'
-import { authOptions, isAdmin } from '@/lib/auth'
 import { GithubAccountLinker } from '@/components/github-account-linker'
 import { SectionHeader } from '@/components/ui/section-header'
 import { FaGithub } from 'react-icons/fa'
@@ -18,17 +16,11 @@ interface GithubLinkingSectionProps {
   } | null
 }
 
-export async function GithubLinkingSection({
+export function GithubLinkingSection({
   personId,
   personName,
   githubAccount,
 }: GithubLinkingSectionProps) {
-  const session = await getServerSession(authOptions)
-
-  if (!session?.user?.organizationId || !isAdmin(session.user)) {
-    return null
-  }
-
   return (
     <section>
       <SectionHeader icon={FaGithub} title='GitHub Linking' />

--- a/src/components/people/sections/jira-linking-section.tsx
+++ b/src/components/people/sections/jira-linking-section.tsx
@@ -1,5 +1,3 @@
-import { getServerSession } from 'next-auth'
-import { authOptions, isAdmin } from '@/lib/auth'
 import { JiraAccountLinker } from '@/components/jira-account-linker'
 import { SectionHeader } from '@/components/ui/section-header'
 import { FaJira } from 'react-icons/fa'
@@ -19,18 +17,12 @@ interface JiraLinkingSectionProps {
   } | null
 }
 
-export async function JiraLinkingSection({
+export function JiraLinkingSection({
   personId,
   personName,
   personEmail,
   jiraAccount,
 }: JiraLinkingSectionProps) {
-  const session = await getServerSession(authOptions)
-
-  if (!session?.user?.organizationId || !isAdmin(session.user)) {
-    return null
-  }
-
   return (
     <section>
       <SectionHeader icon={FaJira} title='Jira Linking' />

--- a/src/components/people/sections/one-on-one-meetings-section.tsx
+++ b/src/components/people/sections/one-on-one-meetings-section.tsx
@@ -1,6 +1,4 @@
 import { prisma } from '@/lib/db'
-import { getServerSession } from 'next-auth'
-import { authOptions } from '@/lib/auth'
 import { SectionHeader } from '@/components/ui/section-header'
 import { Button } from '@/components/ui/button'
 import { MessageCircle } from 'lucide-react'
@@ -8,14 +6,14 @@ import Link from 'next/link'
 
 interface OneOnOneMeetingsSectionProps {
   personId: string
+  organizationId: string
 }
 
 export async function OneOnOneMeetingsSection({
   personId,
+  organizationId,
 }: OneOnOneMeetingsSectionProps) {
-  const session = await getServerSession(authOptions)
-
-  if (!session?.user?.organizationId) {
+  if (!organizationId) {
     return null
   }
 
@@ -23,7 +21,7 @@ export async function OneOnOneMeetingsSection({
   const person = await prisma.person.findFirst({
     where: {
       id: personId,
-      organizationId: session.user.organizationId,
+      organizationId,
     },
     include: {
       reports: true,

--- a/src/components/people/sections/owned-initiatives-section.tsx
+++ b/src/components/people/sections/owned-initiatives-section.tsx
@@ -1,21 +1,19 @@
 import { prisma } from '@/lib/db'
-import { getServerSession } from 'next-auth'
-import { authOptions } from '@/lib/auth'
 import { InitiativesTable } from '@/components/initiatives/initiatives-table'
 import { SectionHeader } from '@/components/ui/section-header'
 import { Rocket } from 'lucide-react'
-import { getPeople } from '@/lib/actions/person'
+import { getActivePeopleForOrganization } from '@/lib/data/people'
 
 interface OwnedInitiativesSectionProps {
   personId: string
+  organizationId: string
 }
 
 export async function OwnedInitiativesSection({
   personId,
+  organizationId,
 }: OwnedInitiativesSectionProps) {
-  const session = await getServerSession(authOptions)
-
-  if (!session?.user?.organizationId) {
+  if (!organizationId) {
     return null
   }
 
@@ -68,12 +66,12 @@ export async function OwnedInitiativesSection({
   }
 
   // Get people data for InitiativesTable
-  const people = await getPeople()
+  const people = await getActivePeopleForOrganization(organizationId)
 
   // Get teams for the InitiativesTable component
   const teams = await prisma.team.findMany({
     where: {
-      organizationId: session.user.organizationId,
+      organizationId,
     },
     orderBy: { name: 'asc' },
   })

--- a/src/components/people/sections/synopsis-section.tsx
+++ b/src/components/people/sections/synopsis-section.tsx
@@ -9,12 +9,16 @@ import Link from 'next/link'
 
 interface SynopsisSectionProps {
   personId: string
+  organizationId: string
 }
 
-export async function SynopsisSection({ personId }: SynopsisSectionProps) {
+export async function SynopsisSection({
+  personId,
+  organizationId,
+}: SynopsisSectionProps) {
   const session = await getServerSession(authOptions)
 
-  if (!session?.user?.organizationId) {
+  if (!session?.user?.organizationId || session.user.organizationId !== organizationId) {
     return null
   }
 
@@ -27,7 +31,7 @@ export async function SynopsisSection({ personId }: SynopsisSectionProps) {
 
   // Get person name for the modal
   const person = await prisma.person.findFirst({
-    where: { id: personId },
+    where: { id: personId, organizationId },
     select: { name: true },
   })
 

--- a/src/components/people/sections/user-linking-section.tsx
+++ b/src/components/people/sections/user-linking-section.tsx
@@ -1,5 +1,3 @@
-import { getServerSession } from 'next-auth'
-import { authOptions, isAdmin } from '@/lib/auth'
 import { UserLinkForm } from '@/components/user-link-form'
 import { SectionHeader } from '@/components/ui/section-header'
 import { User as UserIcon } from 'lucide-react'
@@ -10,16 +8,10 @@ interface UserLinkingSectionProps {
   linkedUser: User | null
 }
 
-export async function UserLinkingSection({
+export function UserLinkingSection({
   personId,
   linkedUser,
 }: UserLinkingSectionProps) {
-  const session = await getServerSession(authOptions)
-
-  if (!session?.user?.organizationId || !isAdmin(session.user)) {
-    return null
-  }
-
   return (
     <section>
       <SectionHeader icon={UserIcon} title='User Linking' />

--- a/src/lib/data/people.ts
+++ b/src/lib/data/people.ts
@@ -1,0 +1,32 @@
+import 'server-only'
+
+import { cache } from 'react'
+import { prisma } from '@/lib/db'
+
+export const getActivePeopleForOrganization = cache(
+  async (organizationId: string) => {
+    if (!organizationId) {
+      return []
+    }
+
+    return prisma.person.findMany({
+      where: {
+        status: 'active',
+        organizationId,
+      },
+      include: {
+        jobRole: {
+          include: {
+            level: true,
+            domain: true,
+          },
+        },
+        team: true,
+        manager: true,
+        reports: true,
+        user: true,
+      },
+      orderBy: { name: 'asc' },
+    })
+  }
+)


### PR DESCRIPTION
## Summary
- pass organization context from the page into each person detail section so they can query without redundant session lookups
- add a cached helper for loading active organization members and reuse it across the initiatives and task sections
- simplify admin-only sidebar sections to avoid unnecessary server action invocations during render

## Testing
- npm run lint *(fails: missing @eslint/eslintrc dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e39da09fd8832696eda81db693c539