### PR TITLE
Add command to create new person

### DIFF
--- a/docs/command-palette.md
+++ b/docs/command-palette.md
@@ -64,7 +64,13 @@ To add new commands:
 
 ### Role-Based Commands
 
-Commands can be conditionally shown based on user roles. The `userRole` parameter is passed to `getItems()` and contains the current user's role ('ADMIN' or 'USER'). Use this to show admin-only commands:
+Commands can be conditionally shown based on user roles. The `userRole` parameter is passed to `getItems()` and contains the current user's role ('ADMIN' or 'USER'). Use this to show admin-only commands.
+
+Admin-only commands currently include:
+- **Create Person** - Add a new person to the organization (navigates to `/people/new`)
+- **Organization Settings** - Manage organization settings
+
+Example:
 
 ```ts
 export const adminSource: CommandSource = {

--- a/src/components/command-palette/sources/core.tsx
+++ b/src/components/command-palette/sources/core.tsx
@@ -10,6 +10,7 @@ import {
   BarChart3,
   Handshake,
   CheckSquare,
+  UserPlus,
 } from 'lucide-react'
 import { type CommandItemDescriptor, type CommandSource } from '../types'
 
@@ -183,18 +184,32 @@ function createStaticItems(
 
   // Add admin-only commands
   if (userRole === 'ADMIN') {
-    items.push({
-      id: 'nav.org-settings',
-      title: 'Organization Settings',
-      subtitle: 'Manage organization settings',
-      icon: <Settings className='h-4 w-4' />,
-      keywords: ['settings', 'organization', 'admin', 'config'],
-      group: 'Administration',
-      perform: ({ closePalette, router }) => {
-        router.push('/organization/settings')
-        closePalette()
+    items.push(
+      {
+        id: 'person.create',
+        title: 'Create Person',
+        subtitle: 'Add a new person to the organization',
+        icon: <UserPlus className='h-4 w-4' />,
+        keywords: ['person', 'people', 'new person', 'add person', 'employee', 'team member'],
+        group: 'Quick Actions',
+        perform: ({ closePalette, router }) => {
+          router.push('/people/new')
+          closePalette()
+        },
       },
-    })
+      {
+        id: 'nav.org-settings',
+        title: 'Organization Settings',
+        subtitle: 'Manage organization settings',
+        icon: <Settings className='h-4 w-4' />,
+        keywords: ['settings', 'organization', 'admin', 'config'],
+        group: 'Administration',
+        perform: ({ closePalette, router }) => {
+          router.push('/organization/settings')
+          closePalette()
+        },
+      }
+    )
   }
 
   return items.filter(item => {


### PR DESCRIPTION
Add a new "Create Person" command to the command palette for admin users to quickly navigate to the person creation page.

---
<a href="https://cursor.com/background-agent?bcId=bc-23692abc-8071-4489-8922-d3eb9fa97d1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-23692abc-8071-4489-8922-d3eb9fa97d1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

