### PR TITLE
Add new meeting command to palette

### DIFF
--- a/docs/command-palette.md
+++ b/docs/command-palette.md
@@ -62,6 +62,27 @@ To add new commands:
 2. Export a `CommandSource` whose `getItems` returns matching `CommandItemDescriptor[]` based on the query.
 3. Register the source in `src/components/command-palette/command-palette.tsx` by adding it to the `sources` array.
 
+### Quick Actions
+
+Quick actions available in the command palette include:
+- **Create Task** - Opens quick task creation modal
+- **Create 1:1 Meeting** - Schedule a new one-on-one meeting
+- **Create Meeting** - Schedule a new team meeting (navigates to `/meetings/new`)
+- **Create Initiative** - Start a new initiative or OKR
+- **Create Feedback** - Give feedback to a team member
+
+### Navigation Commands
+
+Navigation commands to quickly jump to different sections:
+- **View Tasks** - Go to tasks list
+- **View My Tasks** - Go to assigned tasks
+- **View People** - Go to people directory
+- **View Teams** - Go to teams directory
+- **View Initiatives** - Go to initiatives
+- **View Feedback** - Go to feedback page
+- **View Meetings** - Go to meetings page
+- **View Reports** - Go to reports page
+
 ### Role-Based Commands
 
 Commands can be conditionally shown based on user roles. The `userRole` parameter is passed to `getItems()` and contains the current user's role ('ADMIN' or 'USER'). Use this to show admin-only commands.

--- a/roadmap.md
+++ b/roadmap.md
@@ -72,7 +72,7 @@
 - **Breadcrumb Navigation** - Context-aware navigation system
 - **Sidebar Navigation** - Persistent navigation with role-based access
 - **Direct Reports View** - Dedicated manager view of team members
-- **Command Palette** (September 25, 2025) - Global Cmd/Ctrl+K palette with quick actions and search across tasks, initiatives, and people. Extensible sources for commands and server-backed results. Includes Create Task modal trigger.
+- **Command Palette** (September 25, 2025) - Global Cmd/Ctrl+K palette with quick actions and search across tasks, initiatives, people, and meetings. Extensible sources for commands and server-backed results. Includes Create Task modal trigger, Create Meeting command (October 22, 2025), and View Meetings navigation command.
 - **Notification System** (October 1, 2025) - Real-time notifications with bell icon, notification responses (read/dismissed), and full notification management page
 
 ### Data Management

--- a/src/components/command-palette/sources/core.tsx
+++ b/src/components/command-palette/sources/core.tsx
@@ -11,6 +11,7 @@ import {
   Handshake,
   CheckSquare,
   UserPlus,
+  Calendar,
 } from 'lucide-react'
 import { type CommandItemDescriptor, type CommandSource } from '../types'
 
@@ -47,6 +48,18 @@ function createStaticItems(
           ? `/oneonones/new?participant1Id=${currentUserPersonId}`
           : '/oneonones/new'
         router.push(url)
+        closePalette()
+      },
+    },
+    {
+      id: 'meeting.create',
+      title: 'Create Meeting',
+      subtitle: 'Schedule a new team meeting',
+      icon: <Calendar className='h-4 w-4' />,
+      keywords: ['meeting', 'schedule', 'calendar', 'team meeting', 'new meeting'],
+      group: 'Quick Actions',
+      perform: ({ closePalette, router }) => {
+        router.push('/meetings/new')
         closePalette()
       },
     },
@@ -165,6 +178,18 @@ function createStaticItems(
       group: 'Navigation',
       perform: ({ closePalette, router }) => {
         router.push('/feedback')
+        closePalette()
+      },
+    },
+    {
+      id: 'nav.meetings',
+      title: 'View Meetings',
+      subtitle: 'Go to meetings page',
+      icon: <Calendar className='h-4 w-4' />,
+      keywords: ['meetings', 'calendar', 'schedule'],
+      group: 'Navigation',
+      perform: ({ closePalette, router }) => {
+        router.push('/meetings')
         closePalette()
       },
     },


### PR DESCRIPTION
Add "Create Meeting" and "View Meetings" commands to the command palette to enhance meeting management accessibility.

The existing command palette only had a "Create 1:1 Meeting" option, lacking a general meeting creation command. This PR addresses that gap and adds a corresponding navigation command for consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-333b31bc-ba9d-4621-800e-d43bd304cb8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-333b31bc-ba9d-4621-800e-d43bd304cb8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

