### PR TITLE
Update initiative form date picker

### DIFF
--- a/src/components/initiatives/initiative-edit-form.tsx
+++ b/src/components/initiatives/initiative-edit-form.tsx
@@ -19,6 +19,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { DateTimePickerWithNaturalInput } from '@/components/ui/datetime-picker-with-natural-input'
 import { useState } from 'react'
 import { updateInitiative } from '@/lib/actions/initiative'
 import { type InitiativeFormData, initiativeSchema } from '@/lib/validations'
@@ -275,15 +276,13 @@ export function InitiativeEditForm({ initiative }: InitiativeEditFormProps) {
             <CardContent>
               <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
                 <div className='space-y-2'>
-                  <Label htmlFor='startDate'>Start Date</Label>
-                  <Input
-                    id='startDate'
-                    type='date'
+                  <DateTimePickerWithNaturalInput
+                    label='Start Date'
                     value={formData.startDate}
-                    onChange={e =>
-                      handleInputChange('startDate', e.target.value)
-                    }
-                    className={errors.startDate ? 'border-destructive' : ''}
+                    onChange={value => handleInputChange('startDate', value)}
+                    placeholder='Pick start date'
+                    error={!!errors.startDate}
+                    dateOnly={true}
                   />
                   {errors.startDate && (
                     <p className='text-sm text-destructive'>
@@ -293,15 +292,13 @@ export function InitiativeEditForm({ initiative }: InitiativeEditFormProps) {
                 </div>
 
                 <div className='space-y-2'>
-                  <Label htmlFor='targetDate'>Target Date</Label>
-                  <Input
-                    id='targetDate'
-                    type='date'
+                  <DateTimePickerWithNaturalInput
+                    label='Target Date'
                     value={formData.targetDate}
-                    onChange={e =>
-                      handleInputChange('targetDate', e.target.value)
-                    }
-                    className={errors.targetDate ? 'border-destructive' : ''}
+                    onChange={value => handleInputChange('targetDate', value)}
+                    placeholder='Pick target date'
+                    error={!!errors.targetDate}
+                    dateOnly={true}
                   />
                   {errors.targetDate && (
                     <p className='text-sm text-destructive'>

--- a/src/components/initiatives/initiative-form.tsx
+++ b/src/components/initiatives/initiative-form.tsx
@@ -13,6 +13,7 @@ import {
 import { PersonSelect } from '@/components/ui/person-select'
 import { TeamSelect } from '@/components/ui/team-select'
 import { SectionHeader } from '@/components/ui/section-header'
+import { DateTimePickerWithNaturalInput } from '@/components/ui/datetime-picker-with-natural-input'
 import { useState } from 'react'
 import { updateInitiative, createInitiative } from '@/lib/actions/initiative'
 import { type InitiativeFormData, initiativeSchema } from '@/lib/validations'
@@ -285,13 +286,13 @@ export function InitiativeForm({
             <SectionHeader icon={Calendar} title='Timeline' />
             <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
               <div className='space-y-2'>
-                <Label htmlFor='startDate'>Start Date</Label>
-                <Input
-                  id='startDate'
-                  type='date'
+                <DateTimePickerWithNaturalInput
+                  label='Start Date'
                   value={formData.startDate}
-                  onChange={e => handleInputChange('startDate', e.target.value)}
-                  className={errors.startDate ? 'border-destructive' : ''}
+                  onChange={value => handleInputChange('startDate', value)}
+                  placeholder='Pick start date'
+                  error={!!errors.startDate}
+                  dateOnly={true}
                 />
                 {errors.startDate && (
                   <p className='text-sm text-destructive'>{errors.startDate}</p>
@@ -299,15 +300,13 @@ export function InitiativeForm({
               </div>
 
               <div className='space-y-2'>
-                <Label htmlFor='targetDate'>Target Date</Label>
-                <Input
-                  id='targetDate'
-                  type='date'
+                <DateTimePickerWithNaturalInput
+                  label='Target Date'
                   value={formData.targetDate}
-                  onChange={e =>
-                    handleInputChange('targetDate', e.target.value)
-                  }
-                  className={errors.targetDate ? 'border-destructive' : ''}
+                  onChange={value => handleInputChange('targetDate', value)}
+                  placeholder='Pick target date'
+                  error={!!errors.targetDate}
+                  dateOnly={true}
                 />
                 {errors.targetDate && (
                   <p className='text-sm text-destructive'>


### PR DESCRIPTION
Update initiative forms to use the natural language datetime picker in date-only mode for start and target dates.

---
<a href="https://cursor.com/background-agent?bcId=bc-455747ef-7fcd-4d77-839f-93cbdfff1d30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-455747ef-7fcd-4d77-839f-93cbdfff1d30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

