### PR TITLE
Refactor dashboard page to replace old sections with new Highlights, …

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,22 +1,10 @@
 import { requireAuth } from '@/lib/auth-utils'
 import { DashboardOrganizationSetup } from '@/components/dashboard-organization-setup'
 import { Suspense } from 'react'
-import { DashboardAssignedTasksServerSection } from '@/components/dashboard-sections/assigned-tasks-section-server'
-import { DashboardOpenInitiativesServerSection } from '@/components/dashboard-sections/open-initiatives-section-server'
-import { DashboardDirectReportsSection } from '@/components/dashboard-sections/direct-reports-section'
-import { DashboardRelatedTeamsSection } from '@/components/dashboard-sections/related-teams-section'
-import { DashboardRecentOneOnOnesServerSection } from '@/components/dashboard-sections/recent-oneonones-section-server'
-import { DashboardFeedbackCampaignsServerSection } from '@/components/dashboard-sections/feedback-campaigns-section-server'
-import { DashboardUpcomingMeetingsSection } from '@/components/dashboard-sections/upcoming-meetings-section'
-import {
-  TasksServerSectionFallback,
-  OpenInitiativesServerSectionFallback,
-  FeedbackCampaignsSectionFallback,
-  RecentOneOnOnesSectionFallback,
-  RelatedTeamsSectionFallback,
-  DirectReportsSectionFallback,
-  UpcomingMeetingsSectionFallback,
-} from '@/components/dashboard-sections/section-fallbacks'
+import { HighlightsSectionServer } from '@/components/dashboard-sections/highlights-section-server'
+import { TodaysPrioritiesSectionServer } from '@/components/dashboard-sections/todays-priorities-section-server'
+import { ActiveInitiativesSectionServer } from '@/components/dashboard-sections/active-initiatives-section-server'
+import { TeamPulseSectionServer } from '@/components/dashboard-sections/team-pulse-section-server'
 
 export default async function Home() {
   const user = await requireAuth()
@@ -26,54 +14,31 @@ export default async function Home() {
     return <DashboardOrganizationSetup />
   }
 
-  // Sections now fetch their own data via API routes on the client side
-
   return (
     <div className='page-container'>
       <div className='flex flex-col lg:flex-row gap-6'>
         {/* Main Content Area */}
-        <div
-          className='flex-1'
-          style={{
-            display: 'grid',
-            gridTemplateColumns:
-              'repeat(auto-fill, minmax(min(100%, 400px), 1fr))',
-            gap: '1.5rem',
-            alignItems: 'start',
-          }}
-        >
-          <Suspense fallback={<TasksServerSectionFallback />}>
-            <DashboardAssignedTasksServerSection personId={user.personId} />
+        <div className='flex-1 space-y-6'>
+          <Suspense fallback={<div className='h-24 bg-muted/50 rounded-lg animate-pulse' />}>
+            <HighlightsSectionServer />
           </Suspense>
 
-          <Suspense fallback={<FeedbackCampaignsSectionFallback />}>
-            <DashboardFeedbackCampaignsServerSection />
+          <Suspense fallback={<div className='h-64 bg-muted/50 rounded-lg animate-pulse' />}>
+            <TodaysPrioritiesSectionServer />
           </Suspense>
 
-          <Suspense fallback={<OpenInitiativesServerSectionFallback />}>
-            <DashboardOpenInitiativesServerSection
+          <Suspense fallback={<div className='h-64 bg-muted/50 rounded-lg animate-pulse' />}>
+            <ActiveInitiativesSectionServer
               organizationId={user.organizationId!}
               personId={user.personId}
             />
           </Suspense>
-
-          <Suspense fallback={<RecentOneOnOnesSectionFallback />}>
-            <DashboardRecentOneOnOnesServerSection personId={user.personId} />
-          </Suspense>
-
-          <Suspense fallback={<UpcomingMeetingsSectionFallback />}>
-            <DashboardUpcomingMeetingsSection />
-          </Suspense>
         </div>
 
         {/* Right Sidebar */}
-        <div className='w-full lg:w-80 space-y-6'>
-          <Suspense fallback={<RelatedTeamsSectionFallback />}>
-            <DashboardRelatedTeamsSection />
-          </Suspense>
-
-          <Suspense fallback={<DirectReportsSectionFallback />}>
-            <DashboardDirectReportsSection />
+        <div className='w-full lg:w-80'>
+          <Suspense fallback={<div className='h-96 bg-muted/50 rounded-lg animate-pulse' />}>
+            <TeamPulseSectionServer />
           </Suspense>
         </div>
       </div>

--- a/src/components/dashboard-sections/active-initiatives-section-server.tsx
+++ b/src/components/dashboard-sections/active-initiatives-section-server.tsx
@@ -1,0 +1,61 @@
+import { prisma } from '@/lib/db'
+import { ActiveInitiativesSection } from './active-initiatives-section'
+import type { Initiative } from '@/components/initiatives/initiative-list'
+
+interface ActiveInitiativesSectionServerProps {
+  organizationId: string
+  personId: string | null
+}
+
+export async function ActiveInitiativesSectionServer({
+  organizationId,
+  personId,
+}: ActiveInitiativesSectionServerProps) {
+  if (!personId) {
+    return null
+  }
+
+  // Fetch initiatives where current user is an owner
+  const initiatives = await prisma.initiative.findMany({
+    where: {
+      organizationId,
+      owners: {
+        some: { personId },
+      },
+      status: {
+        in: ['in_progress', 'planned'],
+      },
+    },
+    orderBy: { updatedAt: 'desc' },
+    include: {
+      team: {
+        select: {
+          id: true,
+          name: true,
+        },
+      },
+      _count: {
+        select: {
+          tasks: true,
+          checkIns: true,
+          objectives: true,
+        },
+      },
+    },
+    take: 5,
+  })
+
+  // Transform the data to match the Initiative interface
+  const transformedInitiatives: Initiative[] = initiatives.map(initiative => ({
+    id: initiative.id,
+    title: initiative.title,
+    status: initiative.status,
+    rag: initiative.rag,
+    team: initiative.team,
+    updatedAt: initiative.updatedAt,
+    createdAt: initiative.createdAt,
+    _count: initiative._count,
+  }))
+
+  return <ActiveInitiativesSection initiatives={transformedInitiatives} />
+}

--- a/src/components/dashboard-sections/active-initiatives-section.tsx
+++ b/src/components/dashboard-sections/active-initiatives-section.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { Card } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import Link from 'next/link'
+import { formatDistanceToNow } from 'date-fns'
+import { Rocket } from 'lucide-react'
+import type { Initiative } from '@/components/initiatives/initiative-list'
+import { initiativeStatusUtils } from '@/lib/initiative-status'
+import type { InitiativeStatus } from '@/lib/initiative-status'
+
+interface ActiveInitiativesSectionProps {
+  initiatives: Initiative[]
+}
+
+export function ActiveInitiativesSection({
+  initiatives,
+}: ActiveInitiativesSectionProps) {
+  if (initiatives.length === 0) {
+    return null
+  }
+
+  // Filter to only show active initiatives (in_progress, planned)
+  const activeInitiatives = initiatives.filter(
+    init => init.status === 'in_progress' || init.status === 'planned'
+  )
+
+  if (activeInitiatives.length === 0) {
+    return null
+  }
+
+  return (
+    <div className='space-y-4'>
+      <div>
+        <h2 className='text-lg font-semibold'>Active Initiatives</h2>
+        <div className='hidden md:flex items-center gap-2 text-[10px] text-muted-foreground mt-1'>
+          <Link href='/initiatives' className='hover:underline'>
+            View Initiatives
+          </Link>
+        </div>
+      </div>
+      <div className='flex flex-col gap-1.5'>
+        {activeInitiatives.slice(0, 5).map(initiative => (
+          <Link key={initiative.id} href={`/initiatives/${initiative.id}`} className='block'>
+            <Card className='p-3 bg-muted/20 border-0 rounded-md shadow-none hover:bg-muted/30 transition-colors cursor-pointer'>
+              <div className='flex items-center justify-between gap-3'>
+                <div className='flex items-center gap-3 flex-1 min-w-0'>
+                  <Rocket className='h-4 w-4 text-purple-500 shrink-0' />
+                  <div className='flex-1 min-w-0'>
+                    <div className='flex items-center gap-2 flex-wrap'>
+                      <span className='text-sm font-medium truncate'>
+                        {initiative.title}
+                      </span>
+                    </div>
+                    <div className='flex items-center gap-2 text-xs text-muted-foreground mt-1'>
+                      {initiative.team && (
+                        <>
+                          <span className='truncate'>{initiative.team.name}</span>
+                          <span>•</span>
+                        </>
+                      )}
+                      <span>Updated {formatDistanceToNow(initiative.updatedAt, { addSuffix: true })}</span>
+                    </div>
+                  </div>
+                </div>
+                <Badge
+                  variant={initiativeStatusUtils.getVariant(
+                    initiative.status as InitiativeStatus
+                  )}
+                  className='text-xs'
+                >
+                  {initiativeStatusUtils.getLabel(
+                    initiative.status as InitiativeStatus
+                  )}
+                </Badge>
+              </div>
+            </Card>
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/dashboard-sections/highlights-section-server.tsx
+++ b/src/components/dashboard-sections/highlights-section-server.tsx
@@ -1,0 +1,128 @@
+import { getCurrentUser } from '@/lib/auth-utils'
+import { prisma } from '@/lib/db'
+import { HighlightsSection } from './highlights-section'
+import { getTaskAccessWhereClause } from '@/lib/task-access-utils'
+
+export async function HighlightsSectionServer() {
+  const user = await getCurrentUser()
+
+  if (!user.organizationId || !user.personId) {
+    return (
+      <HighlightsSection
+        overdueTasksCount={0}
+        upcomingOneOnOnesCount={0}
+        upcomingMeetingsCount={0}
+        reviewsDueCount={0}
+      />
+    )
+  }
+
+  const now = new Date()
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const oneWeekFromNow = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000)
+
+  // Count overdue tasks
+  const overdueTasks = await prisma.task.findMany({
+    where: {
+      assigneeId: user.personId,
+      dueDate: {
+        lt: startOfToday,
+      },
+      status: {
+        notIn: ['done', 'dropped'],
+      },
+      ...getTaskAccessWhereClause(user.organizationId, user.id, user.personId),
+    },
+  })
+
+  // Count upcoming 1:1s (scheduled in the future)
+  const upcomingOneOnOnes = await prisma.oneOnOne.findMany({
+    where: {
+      OR: [{ managerId: user.personId }, { reportId: user.personId }],
+      scheduledAt: {
+        gte: now,
+        lte: oneWeekFromNow,
+      },
+    },
+  })
+
+  // Count upcoming meetings (instances and non-recurring)
+  const meetingInstances = await prisma.meetingInstance.findMany({
+    where: {
+      scheduledAt: {
+        gte: now,
+        lte: oneWeekFromNow,
+      },
+      OR: [
+        {
+          meeting: {
+            participants: {
+              some: {
+                personId: user.personId,
+              },
+            },
+          },
+        },
+        {
+          participants: {
+            some: {
+              personId: user.personId,
+            },
+          },
+        },
+      ],
+      meeting: {
+        organizationId: user.organizationId,
+      },
+    },
+  })
+
+  const nonRecurringMeetings = await prisma.meeting.findMany({
+    where: {
+      isRecurring: false,
+      scheduledAt: {
+        gte: now,
+        lte: oneWeekFromNow,
+      },
+      organizationId: user.organizationId,
+      OR: [
+        {
+          participants: {
+            some: {
+              personId: user.personId,
+            },
+          },
+        },
+        {
+          createdById: user.id,
+        },
+      ],
+    },
+  })
+
+  const upcomingMeetingsCount = meetingInstances.length + nonRecurringMeetings.length
+
+  // Count reviews due (feedback campaigns ending soon)
+  const reviewsDue = await prisma.feedbackCampaign.findMany({
+    where: {
+      userId: user.id,
+      status: 'active',
+      endDate: {
+        gte: startOfToday,
+        lte: oneWeekFromNow,
+      },
+      targetPerson: {
+        organizationId: user.organizationId,
+      },
+    },
+  })
+
+  return (
+    <HighlightsSection
+      overdueTasksCount={overdueTasks.length}
+      upcomingOneOnOnesCount={upcomingOneOnOnes.length}
+      upcomingMeetingsCount={upcomingMeetingsCount}
+      reviewsDueCount={reviewsDue.length}
+    />
+  )
+}

--- a/src/components/dashboard-sections/highlights-section.tsx
+++ b/src/components/dashboard-sections/highlights-section.tsx
@@ -1,0 +1,74 @@
+import { AlertCircle, Calendar, Users, ClipboardCheck } from 'lucide-react'
+import { Card } from '@/components/ui/card'
+import Link from 'next/link'
+
+interface HighlightsSectionProps {
+  overdueTasksCount: number
+  upcomingOneOnOnesCount: number
+  upcomingMeetingsCount: number
+  reviewsDueCount: number
+}
+
+export function HighlightsSection({
+  overdueTasksCount,
+  upcomingOneOnOnesCount,
+  upcomingMeetingsCount,
+  reviewsDueCount,
+}: HighlightsSectionProps) {
+  const highlights = [
+    {
+      count: overdueTasksCount,
+      label: overdueTasksCount === 1 ? 'overdue task' : 'overdue tasks',
+      icon: AlertCircle,
+      color: 'text-red-500',
+      bgColor: 'bg-red-500/5',
+      href: '/my-tasks',
+    },
+    {
+      count: upcomingOneOnOnesCount,
+      label: upcomingOneOnOnesCount === 1 ? 'upcoming 1:1' : 'upcoming 1:1s',
+      icon: Users,
+      color: 'text-yellow-500',
+      bgColor: 'bg-yellow-500/5',
+      href: '/oneonones',
+    },
+    {
+      count: upcomingMeetingsCount,
+      label: upcomingMeetingsCount === 1 ? 'upcoming meeting' : 'upcoming meetings',
+      icon: Calendar,
+      color: 'text-blue-500',
+      bgColor: 'bg-blue-500/5',
+      href: '/meetings',
+    },
+    {
+      count: reviewsDueCount,
+      label: reviewsDueCount === 1 ? 'review due' : 'reviews due',
+      icon: ClipboardCheck,
+      color: 'text-teal-500',
+      bgColor: 'bg-teal-500/5',
+      href: '/feedback-campaigns',
+    },
+  ]
+
+  return (
+    <div className='space-y-4'>
+      <h2 className='text-lg font-semibold'>Highlights</h2>
+      <div className='flex flex-wrap gap-3'>
+        {highlights.map((highlight, index) => (
+          <Link key={index} href={highlight.href}>
+            <Card
+              className={`flex items-center gap-2 px-4 py-2 ${highlight.bgColor} border-0 rounded-md shadow-none cursor-pointer hover:opacity-80 transition-opacity`}
+            >
+              <div className={`${highlight.color} flex items-center justify-center`}>
+                <highlight.icon className='h-4 w-4' />
+              </div>
+              <span className='text-sm font-medium'>
+                {highlight.count} {highlight.label}
+              </span>
+            </Card>
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/dashboard-sections/team-pulse-section-server.tsx
+++ b/src/components/dashboard-sections/team-pulse-section-server.tsx
@@ -1,0 +1,131 @@
+import { getCurrentUser } from '@/lib/auth-utils'
+import { prisma } from '@/lib/db'
+import { TeamPulseSection } from './team-pulse-section'
+import { format, isFuture, differenceInDays } from 'date-fns'
+
+interface TeamPulseMember {
+  id: string
+  name: string
+  avatar: string | null
+  nextOneOnOne: Date | null
+  lastOneOnOne: Date | null
+  taskCount: number
+  feedbackPending: boolean
+}
+
+export async function TeamPulseSectionServer() {
+  const user = await getCurrentUser()
+
+  if (!user.organizationId || !user.personId) {
+    return null
+  }
+
+  // Get current person's direct reports
+  const directReports = await prisma.person.findMany({
+    where: {
+      managerId: user.personId,
+      organizationId: user.organizationId,
+      status: 'active',
+    },
+    select: {
+      id: true,
+      name: true,
+      avatar: true,
+    },
+    orderBy: { name: 'asc' },
+    take: 10,
+  })
+
+  if (directReports.length === 0) {
+    return null
+  }
+
+  // Get 1:1 meetings for each report
+  const reportIds = directReports.map(r => r.id)
+  const oneOnOnes = await prisma.oneOnOne.findMany({
+    where: {
+      OR: [
+        { managerId: user.personId, reportId: { in: reportIds } },
+        { managerId: { in: reportIds }, reportId: user.personId },
+      ],
+    },
+    select: {
+      managerId: true,
+      reportId: true,
+      scheduledAt: true,
+    },
+    orderBy: { scheduledAt: 'desc' },
+  })
+
+  // Get task counts for each report
+  const tasks = await prisma.task.findMany({
+    where: {
+      assigneeId: { in: reportIds },
+      status: { notIn: ['done', 'dropped'] },
+    },
+    select: {
+      assigneeId: true,
+    },
+  })
+
+  // Get pending feedback campaigns
+  const feedbackCampaigns = await prisma.feedbackCampaign.findMany({
+    where: {
+      userId: user.id,
+      status: 'active',
+      targetPersonId: { in: reportIds },
+      endDate: { gte: new Date() },
+    },
+    select: {
+      targetPersonId: true,
+    },
+  })
+
+  // Build the team pulse data
+  const teamMembers: TeamPulseMember[] = directReports.map(report => {
+    // Find upcoming 1:1
+    const upcomingOneOnOne = oneOnOnes.find(
+      ooo =>
+        ((ooo.managerId === user.personId && ooo.reportId === report.id) ||
+          (ooo.reportId === user.personId && ooo.managerId === report.id)) &&
+        ooo.scheduledAt &&
+        isFuture(new Date(ooo.scheduledAt))
+    )
+
+    // Find most recent past 1:1
+    const pastOneOnOnes = oneOnOnes
+      .filter(
+        ooo =>
+          ((ooo.managerId === user.personId && ooo.reportId === report.id) ||
+            (ooo.reportId === user.personId && ooo.managerId === report.id)) &&
+          ooo.scheduledAt &&
+          !isFuture(new Date(ooo.scheduledAt))
+      )
+      .sort((a, b) => {
+        if (!a.scheduledAt || !b.scheduledAt) return 0
+        return new Date(b.scheduledAt).getTime() - new Date(a.scheduledAt).getTime()
+      })
+
+    const lastOneOnOne = pastOneOnOnes[0]?.scheduledAt || null
+
+    // Count tasks
+    const taskCount = tasks.filter(t => t.assigneeId === report.id).length
+
+    // Check for pending feedback
+    const feedbackPending = feedbackCampaigns.some(
+      fc => fc.targetPersonId === report.id
+    )
+
+    return {
+      id: report.id,
+      name: report.name,
+      avatar: report.avatar,
+      nextOneOnOne: upcomingOneOnOne?.scheduledAt || null,
+      lastOneOnOne,
+      taskCount,
+      feedbackPending,
+    }
+  })
+
+  return <TeamPulseSection members={teamMembers} />
+}

--- a/src/components/dashboard-sections/team-pulse-section.tsx
+++ b/src/components/dashboard-sections/team-pulse-section.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import { Card } from '@/components/ui/card'
+import { PersonAvatar } from '@/components/people/person-avatar'
+import Link from 'next/link'
+import { format, isFuture, differenceInDays } from 'date-fns'
+
+interface TeamPulseMember {
+  id: string
+  name: string
+  avatar: string | null
+  nextOneOnOne: Date | null
+  lastOneOnOne: Date | null
+  taskCount: number
+  feedbackPending: boolean
+}
+
+interface TeamPulseSectionProps {
+  members: TeamPulseMember[]
+}
+
+function formatOneOnOneInfo(
+  nextOneOnOne: Date | null,
+  lastOneOnOne: Date | null
+): string {
+  if (nextOneOnOne && isFuture(new Date(nextOneOnOne))) {
+    const date = new Date(nextOneOnOne)
+    const hours = date.getHours()
+    const minutes = date.getMinutes()
+    const ampm = hours >= 12 ? 'pm' : 'am'
+    const displayHours = hours % 12 || 12
+    return `Next 1:1: ${displayHours}:${minutes.toString().padStart(2, '0')}${ampm}`
+  }
+
+  if (lastOneOnOne) {
+    const daysAgo = differenceInDays(new Date(), new Date(lastOneOnOne))
+    if (daysAgo === 0) {
+      return 'Last 1:1: Today'
+    } else if (daysAgo === 1) {
+      return 'Last 1:1: Yesterday'
+    } else if (daysAgo < 7) {
+      return `Last 1:1: ${daysAgo} days ago`
+    } else {
+      return `Last 1:1: ${format(new Date(lastOneOnOne), 'MMM d')}`
+    }
+  }
+
+  return 'No 1:1s scheduled'
+}
+
+export function TeamPulseSection({ members }: TeamPulseSectionProps) {
+  if (members.length === 0) {
+    return null
+  }
+
+  return (
+    <div className='space-y-4'>
+      <div>
+        <h2 className='text-lg font-semibold'>Team Pulse</h2>
+        <div className='hidden md:flex items-center gap-2 text-[10px] text-muted-foreground mt-1'>
+          <Link href='/direct-reports' className='hover:underline'>
+            View Direct Reports
+          </Link>
+          <span>•</span>
+          <Link href='/teams' className='hover:underline'>
+            View Teams
+          </Link>
+        </div>
+      </div>
+      <div className='flex flex-col gap-2.5'>
+        {members.map(member => (
+          <Link key={member.id} href={`/people/${member.id}`} className='block'>
+            <Card className='p-3 bg-muted/20 border-0 rounded-md shadow-none hover:bg-muted/30 transition-colors cursor-pointer'>
+              <div className='flex items-center gap-3'>
+                <PersonAvatar
+                  name={member.name}
+                  avatar={member.avatar}
+                  size='sm'
+                  className='shrink-0'
+                />
+                <div className='flex-1 min-w-0'>
+                  <div className='font-medium text-sm truncate'>{member.name}</div>
+                  <div className='text-xs text-muted-foreground mt-1'>
+                    {formatOneOnOneInfo(member.nextOneOnOne, member.lastOneOnOne)}
+                  </div>
+                  {(member.taskCount > 0 || member.feedbackPending) && (
+                    <div className='text-xs text-muted-foreground mt-1'>
+                      {member.taskCount > 0 && `• ${member.taskCount} task${member.taskCount === 1 ? '' : 's'}`}
+                      {member.feedbackPending && `• Feedback pending`}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </Card>
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/dashboard-sections/todays-priorities-section-server.tsx
+++ b/src/components/dashboard-sections/todays-priorities-section-server.tsx
@@ -1,0 +1,219 @@
+import { getCurrentUser } from '@/lib/auth-utils'
+import { prisma } from '@/lib/db'
+import { getTaskAccessWhereClause } from '@/lib/task-access-utils'
+import {
+  TodaysPrioritiesSection,
+  type PriorityItem,
+} from './todays-priorities-section'
+
+export async function TodaysPrioritiesSectionServer() {
+  const user = await getCurrentUser()
+
+  if (!user.organizationId || !user.personId) {
+    return null
+  }
+
+  const now = new Date()
+  const oneWeekFromNow = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000)
+
+  const priorityItems: PriorityItem[] = []
+
+  // Fetch incomplete tasks assigned to the current user
+  const tasks = await prisma.task.findMany({
+    where: {
+      assigneeId: user.personId,
+      status: {
+        notIn: ['done', 'dropped'],
+      },
+      ...getTaskAccessWhereClause(user.organizationId, user.id, user.personId),
+    },
+    orderBy: [{ dueDate: { sort: 'asc', nulls: 'last' } }],
+    take: 10,
+  })
+
+  tasks.forEach(task => {
+    priorityItems.push({
+      id: task.id,
+      type: 'task',
+      title: task.title,
+      date: task.dueDate,
+      href: `/tasks/${task.id}`,
+      status: task.status,
+      description: task.description,
+      assigneeId: task.assigneeId,
+      priority: task.priority,
+    })
+  })
+
+  // Fetch upcoming meeting instances where user is a participant
+  const meetingInstances = await prisma.meetingInstance.findMany({
+    where: {
+      scheduledAt: {
+        gte: now,
+        lte: oneWeekFromNow,
+      },
+      OR: [
+        {
+          meeting: {
+            participants: {
+              some: {
+                personId: user.personId,
+              },
+            },
+          },
+        },
+        {
+          participants: {
+            some: {
+              personId: user.personId,
+            },
+          },
+        },
+      ],
+      meeting: {
+        organizationId: user.organizationId,
+      },
+    },
+    include: {
+      meeting: {
+        select: {
+          title: true,
+        },
+      },
+    },
+    orderBy: {
+      scheduledAt: 'asc',
+    },
+    take: 5,
+  })
+
+  meetingInstances.forEach(instance => {
+    priorityItems.push({
+      id: instance.id,
+      type: 'meeting',
+      title: instance.meeting.title,
+      date: instance.scheduledAt,
+      href: `/meetings/${instance.meetingId}/instances/${instance.id}`,
+    })
+  })
+
+  // Fetch non-recurring meetings where user is a participant
+  const nonRecurringMeetings = await prisma.meeting.findMany({
+    where: {
+      isRecurring: false,
+      scheduledAt: {
+        gte: now,
+        lte: oneWeekFromNow,
+      },
+      organizationId: user.organizationId,
+      OR: [
+        {
+          participants: {
+            some: {
+              personId: user.personId,
+            },
+          },
+        },
+        {
+          createdById: user.id,
+        },
+      ],
+    },
+    select: {
+      id: true,
+      title: true,
+      scheduledAt: true,
+    },
+    orderBy: {
+      scheduledAt: 'asc',
+    },
+    take: 5,
+  })
+
+  nonRecurringMeetings.forEach(meeting => {
+    priorityItems.push({
+      id: meeting.id,
+      type: 'meeting',
+      title: meeting.title,
+      date: meeting.scheduledAt,
+      href: `/meetings/${meeting.id}`,
+    })
+  })
+
+  // Fetch upcoming 1:1s
+  const oneOnOnes = await prisma.oneOnOne.findMany({
+    where: {
+      OR: [{ managerId: user.personId }, { reportId: user.personId }],
+      scheduledAt: {
+        gte: now,
+        lte: oneWeekFromNow,
+      },
+    },
+    include: {
+      manager: {
+        select: {
+          name: true,
+        },
+      },
+      report: {
+        select: {
+          name: true,
+        },
+      },
+    },
+    orderBy: {
+      scheduledAt: 'asc',
+    },
+    take: 5,
+  })
+
+  oneOnOnes.forEach(ooo => {
+    const otherPerson =
+      user.personId === ooo.managerId ? ooo.report : ooo.manager
+    priorityItems.push({
+      id: ooo.id,
+      type: 'oneonone',
+      title: `1:1 with ${otherPerson.name}`,
+      date: ooo.scheduledAt,
+      href: `/oneonones/${ooo.id}`,
+    })
+  })
+
+  // Fetch active feedback campaigns created by user (ending within a week, or all active if none ending soon)
+  const feedbackCampaigns = await prisma.feedbackCampaign.findMany({
+    where: {
+      userId: user.id,
+      status: 'active',
+      endDate: {
+        gte: now,
+      },
+      targetPerson: {
+        organizationId: user.organizationId,
+      },
+    },
+    include: {
+      targetPerson: {
+        select: {
+          name: true,
+        },
+      },
+    },
+    orderBy: {
+      endDate: 'asc',
+    },
+    take: 5,
+  })
+
+  feedbackCampaigns.forEach(campaign => {
+    priorityItems.push({
+      id: campaign.id,
+      type: 'feedback',
+      title: `Feedback: ${campaign.targetPerson.name}`,
+      date: campaign.endDate,
+      href: `/people/${campaign.targetPersonId}/feedback-campaigns/${campaign.id}`,
+      metadata: campaign.name || undefined,
+    })
+  })
+
+  return <TodaysPrioritiesSection items={priorityItems} />
+}


### PR DESCRIPTION
…Today's Priorities, Active Initiatives, and Team Pulse sections. Removed unused imports and adjusted layout for improved structure and performance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors the dashboard to new data-driven sections with server-side fetching and streamlined skeleton fallbacks.
> 
> - **Dashboard**:
>   - Replace legacy sections with new `HighlightsSectionServer`, `TodaysPrioritiesSectionServer`, `ActiveInitiativesSectionServer`, and `TeamPulseSectionServer` in `src/app/dashboard/page.tsx`.
>   - Simplify layout and use lightweight Suspense skeleton fallbacks.
> - **New Sections**:
>   - `highlights-section(-server).tsx`: Counts overdue tasks, upcoming 1:1s, meetings (instances and non-recurring), and reviews due (feedback campaigns) using Prisma; renders compact highlight chips with links.
>   - `todays-priorities-section(-server).tsx`: Aggregates next-week tasks/meetings/1:1s/feedback into prioritized list (overdue first), supports task quick-edit dialog and refresh; Prisma-powered queries with access control.
>   - `active-initiatives-section(-server).tsx`: Fetches up to 5 owned initiatives with team and counts; client displays status badge and last updated.
>   - `team-pulse-section(-server).tsx`: Builds direct reports pulse (next/last 1:1, open task count, pending feedback) and renders navigable list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56d78ad2bf1ee66f1e4a020cdcdd7ff541530172. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->