### PR TITLE
refactor: remove unused select fields from reports queries in people-stats-lists

### DIFF
--- a/src/lib/actions/people-stats-lists.ts
+++ b/src/lib/actions/people-stats-lists.ts
@@ -89,14 +89,6 @@ export async function getReportsWithoutRecentOneOnOne(): Promise<
             },
           },
         },
-        select: {
-          id: true,
-          name: true,
-          email: true,
-          role: true,
-          status: true,
-          birthday: true,
-        },
       },
       reports: {
         select: {
@@ -299,14 +291,6 @@ export async function getReportsWithoutRecentFeedback360(): Promise<
               birthday: true,
             },
           },
-        },
-        select: {
-          id: true,
-          name: true,
-          email: true,
-          role: true,
-          status: true,
-          birthday: true,
         },
       },
       reports: {


### PR DESCRIPTION
- Eliminated redundant select fields (id, name, email, role, status, birthday) from the reports queries in getReportsWithoutRecentOneOnOne and getReportsWithoutRecentFeedback360 functions to streamline data retrieval.
