### PR TITLE
feat(initiatives): refactor initiatives slots view and enhance filtering capabilities

### DIFF
--- a/src/app/(app)/initiatives/slots/page.tsx
+++ b/src/app/(app)/initiatives/slots/page.tsx
@@ -7,8 +7,8 @@ import { getActionPermission, getCurrentUser } from '@/lib/auth-utils'
 import { InitiativesListActionsDropdown } from '@/components/initiatives/initiatives-list-actions-dropdown'
 import { InitiativesViewDropdown } from '@/components/initiatives/initiatives-view-dropdown'
 import { PageBreadcrumbSetter } from '@/components/page-breadcrumb-setter'
-import { InitiativesSlotsView } from '@/components/initiatives/initiatives-slots-view'
 import { getSlottedInitiatives } from '@/lib/actions/initiative'
+import { SlotsPageClient } from '@/components/initiatives/slots-page-client'
 
 export default async function InitiativesSlotsPage() {
   const user = await getCurrentUser()
@@ -45,7 +45,7 @@ export default async function InitiativesSlotsPage() {
         />
         <PageContent>
           <PageSection>
-            <InitiativesSlotsView
+            <SlotsPageClient
               slottedInitiatives={slottedInitiatives}
               unslottedInitiatives={unslottedInitiatives}
               totalSlots={totalSlots}

--- a/src/components/common/view-dropdown.tsx
+++ b/src/components/common/view-dropdown.tsx
@@ -205,9 +205,9 @@ export function ViewDropdown({
           <PopoverTrigger asChild>
             <Button
               variant='outline'
-              size='icon-lg'
+              size='sm'
               className={cn(
-                'flex items-center gap-md px-md',
+                'flex items-center gap-md',
                 hasActiveSettings && 'border-primary bg-primary/5',
                 className
               )}

--- a/src/components/initiatives/initiatives-slots-filters.tsx
+++ b/src/components/initiatives/initiatives-slots-filters.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { useTeamsCache } from '@/hooks/use-organization-cache'
+import { usePeopleForSelect } from '@/hooks/use-organization-cache'
+import {
+  MultiSelect,
+  type MultiSelectOption,
+} from '@/components/ui/multi-select'
+
+export interface InitiativeSlotsFilters {
+  teamIds: string[]
+  personIds: string[]
+}
+
+interface InitiativesSlotsFiltersProps {
+  filters: InitiativeSlotsFilters
+  onFiltersChange: (filters: InitiativeSlotsFilters) => void
+}
+
+export function InitiativesSlotsFilters({
+  filters,
+  onFiltersChange,
+}: InitiativesSlotsFiltersProps) {
+  const { teams } = useTeamsCache()
+  const { people } = usePeopleForSelect()
+
+  const teamOptions: MultiSelectOption[] = teams.map(team => ({
+    value: team.id,
+    label: team.name,
+  }))
+
+  const personOptions: MultiSelectOption[] = people.map(person => ({
+    value: person.id,
+    label: person.name,
+  }))
+
+  const handleTeamFilterChange = (selected: string[]) => {
+    onFiltersChange({
+      ...filters,
+      teamIds: selected,
+    })
+  }
+
+  const handlePersonFilterChange = (selected: string[]) => {
+    onFiltersChange({
+      ...filters,
+      personIds: selected,
+    })
+  }
+
+  return (
+    <div className='space-y-3'>
+      <div className='space-y-2'>
+        <label className='text-sm font-medium'>Team</label>
+        <MultiSelect
+          options={teamOptions}
+          selected={filters.teamIds}
+          onChange={handleTeamFilterChange}
+          placeholder='All teams'
+        />
+      </div>
+
+      <div className='space-y-2'>
+        <label className='text-sm font-medium'>Owner</label>
+        <MultiSelect
+          options={personOptions}
+          selected={filters.personIds}
+          onChange={handlePersonFilterChange}
+          placeholder='All owners'
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/components/initiatives/slots-page-client.tsx
+++ b/src/components/initiatives/slots-page-client.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+import { InitiativesSlotsView } from './initiatives-slots-view'
+import {
+  InitiativesSlotsFilters,
+  type InitiativeSlotsFilters,
+} from './initiatives-slots-filters'
+import { ViewDropdown } from '@/components/common/view-dropdown'
+import type { SlotInitiative } from './slot-card'
+
+interface SlotsPageClientProps {
+  slottedInitiatives: SlotInitiative[]
+  unslottedInitiatives: SlotInitiative[]
+  totalSlots: number
+}
+
+export function SlotsPageClient({
+  slottedInitiatives,
+  unslottedInitiatives,
+  totalSlots,
+}: SlotsPageClientProps) {
+  const [filters, setFilters] = useState<InitiativeSlotsFilters>({
+    teamIds: [],
+    personIds: [],
+  })
+
+  const hasActiveFilters = useMemo(
+    () => filters.teamIds.length > 0 || filters.personIds.length > 0,
+    [filters]
+  )
+
+  const handleClearFilters = () => {
+    setFilters({
+      teamIds: [],
+      personIds: [],
+    })
+  }
+
+  return (
+    <>
+      <div className='flex items-center justify-end mb-4'>
+        <ViewDropdown
+          groupingValue='none'
+          onGroupingChange={() => {}}
+          groupingOptions={[]}
+          sortField=''
+          sortDirection='asc'
+          onSortChange={() => {}}
+          sortOptions={[]}
+          hasActiveFilters={hasActiveFilters}
+          onClearFilters={handleClearFilters}
+          filterContent={
+            <InitiativesSlotsFilters
+              filters={filters}
+              onFiltersChange={setFilters}
+            />
+          }
+          title='Display'
+        />
+      </div>
+      <InitiativesSlotsView
+        slottedInitiatives={slottedInitiatives}
+        unslottedInitiatives={unslottedInitiatives}
+        totalSlots={totalSlots}
+        filters={filters}
+      />
+    </>
+  )
+}


### PR DESCRIPTION
- Replaced the `InitiativesSlotsView` component with `SlotsPageClient` in the `InitiativesSlotsPage`.
- Added filtering logic to the `InitiativesSlotsView`, allowing users to filter initiatives based on team and person IDs.
- Updated the `SlotCard` component to handle filtered states, preventing drag-and-drop actions when filters are active.
- Improved performance by utilizing `useMemo` for slot mapping.
- Adjusted styling and behavior of components to reflect filtered states.
