### PR TITLE
feat(initiatives): enhance initiative querying with user context

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -131,6 +131,34 @@ Key guidelines:
 - When asked about the CURRENT USER'S OWN Jira activity (e.g., "my tickets", "my Jira issues"), call the jira tool WITHOUT providing a personId - it will automatically use the current user's linked account.
 - When asked about ANOTHER PERSON'S Jira activity, FIRST use personLookup to get their person ID, then use the jira tool with that personId parameter.
 - Do NOT include author:, involves:, or other username qualifiers in GitHub/Jira queries - the tools will automatically add the correct username.
+- When asked about the CURRENT USER'S OWN initiatives (e.g., "my initiatives", "initiatives I'm involved in", "what initiatives am I working on"), FIRST use the currentUser tool to get the current user's person ID, then use the initiatives tool with that personId parameter to filter initiatives where the person is an owner.
+- When asked about ANOTHER PERSON'S initiatives (e.g., "John's initiatives", "initiatives Sarah is working on"), FIRST use personLookup to get their person ID, then use the initiatives tool with that personId parameter.
+- When asked about "what should I do today", "what should I focus on this week", "what are my priorities", or similar work prioritization queries, provide intelligent, prioritized suggestions by:
+  * FIRST use the dateTime tool to get the current date and week boundaries
+  * Use the currentUser tool to get the current user's person ID and check if they have direct reports
+  * Fetch tasks assigned to the user using the tasks tool with assigneeId matching the current user's person ID, filtering by status (exclude 'done', 'dropped')
+  * Fetch initiatives the user is involved in using the initiatives tool with personId matching the current user's person ID
+  * For each initiative, analyze:
+    - Check-in frequency: If checkInsCount is 0 or very low, suggest adding a check-in as a priority
+    - Update recency: Consider initiatives that may be stale (no recent updates, old target dates) and suggest reviewing them
+  * If the user has direct reports (from currentUser tool response):
+    - Use the people tool with managerIs parameter set to the current user's person ID to get the list of direct reports
+    - For each direct report, consider:
+      * If they haven't had a 1:1 recently (more than 1-2 weeks ago), suggest scheduling a 1:1 as a priority
+      * If they are in onboarding (status 'IN_PROGRESS' or 'NOT_STARTED'), suggest checking in on their onboarding progress
+  * Analyze and prioritize all suggestions based on:
+    - Tasks with due dates in the next 1-7 days (earlier due dates = higher priority)
+    - Tasks related to initiatives with upcoming target dates
+    - Task priority levels (1 = highest priority)
+    - Initiative priority and status (active initiatives take precedence)
+    - Initiatives with no check-ins or very few check-ins (suggest adding a check-in)
+    - Initiatives that haven't been updated recently (may need attention to avoid going stale)
+    - Direct reports who need 1:1s (overdue 1:1s = high priority)
+    - Direct reports in active onboarding (supporting onboarding = high priority)
+  * Provide suggestions in order of priority with clear reasoning, organized into:
+    - Task-focused suggestions (due dates, initiative relationships)
+    - Initiative maintenance suggestions (check-ins needed, stale initiatives)
+    - People management suggestions (1:1s, onboarding support)
 - When a user wants to CREATE or SCHEDULE a 1:1 meeting (e.g., "create a 1:1 with Alex", "schedule a meeting with John tomorrow at 2pm"), use the createOneOnOneAction tool. Extract the other participant's name and any date/time information from the user's prompt. The tool will handle identifying the current user and the other participant, parse date/time if provided, and return a navigation URL to the pre-filled form.
 - Extract date/time information from the user's prompt when creating 1:1s (e.g., "tomorrow at 2pm", "next Monday", "December 25th at 3pm") and pass it as the scheduledAt parameter - it can be natural language as the tool will parse it.
 - When a user wants to CREATE or ADD a new person (e.g., "create a person named John Smith", "add Sarah to the Engineering team", "create a person named Alex who reports to John", "create a person who reports to me"), use the createPersonAction tool. Extract the person's name, team name, and manager name (the person they report to) from the user's prompt. If the user says "reports to me", "reports to myself", "reports to I", uses their own name as the manager, or refers to themselves in any way, pass that reference (e.g., "me", "myself", or their name) as the managerName parameter - the tool will automatically detect self-references and use the current user as the manager. The tool will look up the team and manager if provided and return a navigation URL to the pre-filled person creation form.

--- a/src/lib/ai/tools/initiatives-tool.ts
+++ b/src/lib/ai/tools/initiatives-tool.ts
@@ -5,7 +5,7 @@ import type { Prisma } from '@/generated/prisma'
 
 export const initiativesTool = {
   description:
-    'Get information about specific initiatives in the organization. It uses things like status, RAG, team and owners/collaborators, keywords, teams, priority, or slot assignment to filter the list. The initiatives returned are limited to this filter. Use this tool with each new query as opposed to using previous responses for future queries.',
+    'Get information about specific initiatives in the organization. It uses things like status, RAG, team and owners/collaborators, keywords, teams, priority, or slot assignment to filter the list. The initiatives returned are limited to this filter. Use this tool with each new query as opposed to using previous responses for future queries. IMPORTANT: When the user asks about "my initiatives", "initiatives I\'m involved in", or anything related to their own initiatives, FIRST use the currentUser tool to get the current user\'s person ID, then use this tool with that personId parameter.',
   parameters: z.object({
     status: z
       .enum(['planned', 'in_progress', 'paused', 'done', 'canceled'])
@@ -19,7 +19,7 @@ export const initiativesTool = {
       .string()
       .optional()
       .describe(
-        'Filter by people who are in the list of owners of the initiative. This is the ID of the person - use the prompt to look up the person using a different tool and pass in the ID of the person here.'
+        'Filter by people who are in the list of owners of the initiative. This is the ID of the person. When the user asks about "my initiatives" or refers to themselves (e.g., "I", "me", "my"), FIRST use the currentUser tool to get their person ID, then pass it here. For other people, use the personLookup tool to find their person ID.'
       ),
     teamId: z.string().optional().describe('Filter by team ID'),
     query: z


### PR DESCRIPTION
- Updated the initiatives tool to include user context for queries related to "my initiatives" and other personal initiative inquiries.
- Added guidelines for prioritizing user tasks and suggestions based on current initiatives and direct reports.
- Improved the description of the initiatives tool to clarify the use of currentUser and personLookup for accurate filtering.
